### PR TITLE
simple npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "./node_modules/gulp/bin/gulp.js",
-    "test": "./node_modules/gulp/bin/gulp.js test"
+    "build": "gulp",
+    "test": "gulp test"
   },
   "author": "Takayuki Miyauchi",
   "license": "GPL",


### PR DESCRIPTION
npm scriptでは`/node_modules/.bin/`以下はPATH通ってるのと同様になる(ハズ)なので余分な部分を省略。
